### PR TITLE
Add Vercel Analytics to frontend

### DIFF
--- a/frontend/project/package-lock.json
+++ b/frontend/project/package-lock.json
@@ -37,6 +37,7 @@
                 "@radix-ui/react-toggle": "^1.1.0",
                 "@radix-ui/react-toggle-group": "^1.1.0",
                 "@radix-ui/react-tooltip": "^1.1.2",
+                "@vercel/analytics": "^1.5.0",
                 "axios": "^1.11.0",
                 "class-variance-authority": "^0.7.0",
                 "clsx": "^2.1.1",
@@ -4538,6 +4539,44 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@vercel/analytics": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+            "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+            "license": "MPL-2.0",
+            "peerDependencies": {
+                "@remix-run/react": "^2",
+                "@sveltejs/kit": "^1 || ^2",
+                "next": ">= 13",
+                "react": "^18 || ^19 || ^19.0.0-rc",
+                "svelte": ">= 4",
+                "vue": "^3",
+                "vue-router": "^4"
+            },
+            "peerDependenciesMeta": {
+                "@remix-run/react": {
+                    "optional": true
+                },
+                "@sveltejs/kit": {
+                    "optional": true
+                },
+                "next": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "svelte": {
+                    "optional": true
+                },
+                "vue": {
+                    "optional": true
+                },
+                "vue-router": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@vitejs/plugin-react": {

--- a/frontend/project/package.json
+++ b/frontend/project/package.json
@@ -47,6 +47,7 @@
         "@radix-ui/react-toggle": "^1.1.0",
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.2",
+        "@vercel/analytics": "^1.5.0",
         "axios": "^1.11.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",

--- a/frontend/project/src/main.tsx
+++ b/frontend/project/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { registerSW } from 'virtual:pwa-register';
+import { Analytics } from '@vercel/analytics/react';
 import App from './App.tsx';
 import './index.css';
 
@@ -20,5 +21,6 @@ const updateSW = registerSW({
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
+    <Analytics />
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- add the Vercel Analytics package to the frontend project dependencies
- render the Analytics component alongside the app root so page views are tracked

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d23ac994288324a8fe4756351f4f8a